### PR TITLE
docs: Add architecture diagrams (components, domain models, cache lifecycle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ The following diagram illustrates the typical request flow when a developer asks
 
 ![Sequence Flow Diagram](docs/sequence_flow.puml)
 
+### Component Diagram
+
+This diagram visualizes the physical and logical boundaries of the server, demonstrating that it relies completely on stdio and does not expose local HTTP/TCP ports.
+
+![Component Diagram](docs/architecture/components.puml)
+
+### Domain Models
+
+This diagram illustrates the core TypeScript entities and properties of the GitLabService cache singleton.
+
+![Domain Models](docs/architecture/domain_models.puml)
+
+### Cache Lifecycle
+
+This state machine visualizes the 5-minute Time-To-Live (TTL) and validation logic of the in-memory cache to prevent excessive API requests to GitLab.
+
+![Cache Lifecycle](docs/architecture/cache_lifecycle.puml)
+
 ## Prerequisites
 
 - Node.js (v18 or higher)

--- a/docs/architecture/cache_lifecycle.puml
+++ b/docs/architecture/cache_lifecycle.puml
@@ -1,0 +1,28 @@
+@startuml
+
+[*] --> Empty
+
+state "Empty / Uninitialized" as Empty
+state "FetchingFromGitLab" as Fetching
+state "Cached (Valid)" as Cached
+state "Expired (TTL > 5 min)" as Expired
+
+Empty --> Fetching : listTemplates()\nor getTemplate(id) called
+Fetching --> Cached : Data fetched successfully.\nUpdate lastFetch = Date.now()
+Cached --> Cached : listTemplates() / getTemplate(id)\nTime elapsed < cacheTTL
+Cached --> Expired : Time elapsed >= cacheTTL\n(5 minutes)
+Expired --> Fetching : listTemplates()\nor getTemplate(id) called
+
+note right of Cached
+  In Valid Cached state, templates
+  are returned immediately from memory,
+  avoiding GitLab API calls.
+end note
+
+note right of Expired
+  When expired, the next request will
+  trigger a fresh fetch from GitLab API
+  to prevent stale data and avoid rate limits.
+end note
+
+@enduml

--- a/docs/architecture/components.puml
+++ b/docs/architecture/components.puml
@@ -1,0 +1,26 @@
+@startuml
+skinparam componentStyle uml2
+
+actor "AI Client (e.g., Copilot, Claude)" as Client
+
+node "Standalone MCP Server" {
+  component "@modelcontextprotocol/sdk" as SDK <<Transport Layer>>
+  component "GitLabService" as GitLabService <<Domain Logic>>
+  component "In-Memory Cache" as Cache <<Module>>
+}
+
+cloud "GitLab Instance" {
+  component "GitLab API" as GitLabAPI <<External Service>>
+}
+
+Client <--> SDK : JSON-RPC over stdio\n(stdin/stdout)
+SDK <--> GitLabService : internal method calls
+GitLabService <--> Cache : read/write templates\n(TTL based)
+GitLabService <--> GitLabAPI : HTTPS (REST)
+
+note right of SDK
+  The server relies entirely on stdio.
+  It does not expose any local HTTP/TCP ports.
+end note
+
+@enduml

--- a/docs/architecture/domain_models.puml
+++ b/docs/architecture/domain_models.puml
@@ -1,0 +1,39 @@
+@startuml
+
+interface TemplateManifest {
+  +id: string
+  +name: string
+  +description: string
+  +tags: string[]
+  +files: string[]
+  +path?: string
+}
+
+interface Template {
+  +manifest: TemplateManifest
+  +content: Record<string, string>
+}
+
+class GitLabService <<Singleton>> {
+  -axiosInstance: AxiosInstance
+  -cache: Map<string, Template>
+  -listCache: TemplateManifest[] | null
+  -cacheTTL: number = 300000
+  -lastFetch: number
+  --
+  +constructor()
+  -fetchFile(path: string): Promise<string>
+  +listTemplates(): Promise<TemplateManifest[]>
+  +getTemplate(id: string): Promise<Template | null>
+  +searchTemplates(query: string): Promise<TemplateManifest[]>
+}
+
+GitLabService "1" *-- "0..*" TemplateManifest : listCache
+GitLabService "1" *-- "0..*" Template : cache
+Template "1" *-- "1" TemplateManifest : manifest
+
+note bottom of GitLabService
+  The cacheTTL is 5 minutes (300000ms).
+end note
+
+@enduml


### PR DESCRIPTION
Closes issue "Epic: AI Tooling & Context (Standalone MCP Server)" which asked for architecture documentation. I have implemented the three requested PlantUML diagrams and embedded them into the README.md file.

---
*PR created automatically by Jules for task [13640030798684490529](https://jules.google.com/task/13640030798684490529) started by @tkpixel*